### PR TITLE
Add node-sass-magic-importer

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,5 +1,6 @@
 var sass   = require('node-sass'),
-    extend = require('util')._extend;
+    extend = require('util')._extend,
+    magicImporter = require('node-sass-magic-importer');
 
 function getProperty(obj, name){
     name = name.replace(/\[(\w+)\]/g, '.$1').replace(/^\./, '');
@@ -42,6 +43,7 @@ var sassRenderer = function(data, options, callback) {
         file: data.path,
         outputStyle: 'nested',
         sourceComments: false,
+        importer: magicImporter(),
         functions: {
             "hexo-theme-config($ckey)": function(ckey) {
                 var val = getProperty(themeCfg, ckey.getValue()),
@@ -69,8 +71,8 @@ var sassRenderer = function(data, options, callback) {
             return;
         }
         callback(null, res.css.toString());
-    }); 
-   
+    });
+
 };
 
 module.exports = sassRenderer;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "hexo": ">= 3.0.0"
   },
   "dependencies": {
-    "node-sass": "^3.8.0"
+    "node-sass": "^3.8.0",
+    "node-sass-magic-importer": "^4.1.5"
   },
   "bugs": {
     "url": "https://github.com/mamboer/hexo-renderer-scss/issues"


### PR DESCRIPTION
I needed some more advanced SCSS module resolving in my current Hexo project so I added [`node-sass-magic-importer`](https://github.com/maoberlehner/node-sass-magic-importer). It's entirely backwards-compatible with regular SCSS imports but adds support for resolving imports from `node_modules`, named imports, glob imports and so on.

Thought someone else might need it as well.